### PR TITLE
Remove pull to refresh component

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "react-hammerjs": "^0.5.0",
     "react-headroom": "^2.1.3",
     "react-intl": "^2.1.5",
-    "react-pull-to-refresh": "latest",
     "react-redux": "^5.0.0",
     "react-responsive-modal": "^1.2.3",
     "react-router": "^3.0.0",

--- a/src/routes/App/components/Nobt.js
+++ b/src/routes/App/components/Nobt.js
@@ -67,7 +67,7 @@ export default class Nobt extends React.Component {
         {
           this.props.fetchStatus === AsyncActionStatus.SUCCESSFUL && (
 
-            <ReactPullToRefresh onRefresh={this.props.invalidateNobtData}>
+            <div>
 
               <div className={BillListTheme.header}>
                 <div className={BillListTheme.title}>
@@ -100,7 +100,7 @@ export default class Nobt extends React.Component {
 
               {this.props.children}
 
-            </ReactPullToRefresh>
+            </div>
           )
         }
 


### PR DESCRIPTION
Replacing the pull-to-refresh component with a regular div allows the page to be scrollable again.