### PR TITLE
Wait for the bill to be added to the nobt before exiting the form screen

### DIFF
--- a/src/routes/App/routes/new/components/AddBillForm.js
+++ b/src/routes/App/routes/new/components/AddBillForm.js
@@ -12,6 +12,8 @@ import AddMember from "./AddMember";
 import { Link } from "react-router";
 import LocationBuilder from "../../../modules/navigation/LocationBuilder";
 import ShareListTheme from "./ShareList/ShareListTheme.scss";
+import AsyncActionStatus from "../../../../../const/AsyncActionStatus";
+import { Snackbar } from "react-toolbox";
 
 /*
  TODO:
@@ -43,14 +45,14 @@ export default class AddBillForm extends React.Component {
     this.props.onSubmit(this.props.nobtId, billToAdd);
   };
 
-  handleOnSplitStrategyChanged = (splitStrategy) => {
-    this.props.onSplitStrategyChanged(splitStrategy);
-    this.closeSplitStrategySelectorOverlay();
-  };
+  componentWillReceiveProps(nextProps) {
+    let newStatus = nextProps.addBillStatus;
 
-  handleOnEqualSplitStrategySelected = () => { this.handleOnSplitStrategyChanged(SplitStrategyNames.EQUAL); }
-  handleOnCustomSplitStrategySelected = () => { this.handleOnSplitStrategyChanged(SplitStrategyNames.UNEQUAL); }
-  handleOnPercentalSplitStrategySelected = () => { this.handleOnSplitStrategyChanged(SplitStrategyNames.PERCENTAGE); }
+    if (newStatus === AsyncActionStatus.SUCCESSFUL) {
+      this.props.replace(LocationBuilder.fromWindow().pop(1).path);
+      this.props.invalidateNobt()
+    }
+  }
 
   render = () => {
 
@@ -73,7 +75,7 @@ export default class AddBillForm extends React.Component {
               <Link to={LocationBuilder.fromWindow().push("selectDebtee").path}>
                 <Input /* TODO: Using input is just a hack for the moment, remove later and style accordingly */
                   readOnly theme={inputTheme} icon="person" placeholder="Who paid?" value={this.props.debtee || ""}>
-                  <div className={styles.overlayToAvoidKeyboardPopingUp}></div>
+                  <div className={styles.overlayToAvoidKeyboardPopingUp}/>
                 </Input>
               </Link>
 
@@ -110,6 +112,14 @@ export default class AddBillForm extends React.Component {
         </div>
 
         {this.props.children}
+
+        <Snackbar
+          action='Retry?'
+          active={this.props.addBillStatus === AsyncActionStatus.FAILED}
+          label='Failed to add bill.'
+          type='warning'
+          onClick={this.handleOnSubmit}
+        />
       </div>
     )
   }

--- a/src/routes/App/routes/new/containers/AddBillFormContainer.js
+++ b/src/routes/App/routes/new/containers/AddBillFormContainer.js
@@ -1,6 +1,6 @@
 import React from "react";
 import AddBillForm from "../components/AddBillForm";
-import { getAmount, getDebtee, getDescription, getSplitStrategy, getShares, isValidBill } from "../modules/addBillForm/selectors";
+import { getAmount, getDebtee, getDescription, getSplitStrategy, getShares, isValidBill, getAddBillStatus } from "../modules/addBillForm/selectors";
 import { connect } from "react-redux";
 import LocationBuilder from "../../../modules/navigation/LocationBuilder";
 import { addBill } from "../modules/addBillForm/actions";
@@ -8,6 +8,7 @@ import { invalidateNobt } from "../../../modules/currentNobt/actions";
 
 export default connect((state, ownProps) => {
   return {
+    addBillStatus: getAddBillStatus(state),
     canSubmit: isValidBill(state),
     amount: getAmount(state),
     description: getDescription(state),
@@ -19,16 +20,13 @@ export default connect((state, ownProps) => {
 }, (dispatch, props) => {
   return {
     onCancel: () => props.replace(LocationBuilder.fromWindow().pop(1).path),
-    onSubmit: (id, bill) => {
-      dispatch(addBill(id, bill));
-      props.replace(LocationBuilder.fromWindow().pop(1).path);
-      dispatch(invalidateNobt());
-    },
+    onSubmit: (id, bill) => dispatch(addBill(id, bill)),
     onNewMember: (member) => dispatch({type: "NewMemberAdded", payload: {member: member}}),
     onShareValueChanged: (name, value) => dispatch({type: "ShareValueChanged", payload: {name, value}}),
     onSplitStrategyChanged: (splitStrategy) => dispatch({type: "SplitStrategyChanged", payload: {strategy: splitStrategy}}),
     onAmountChanged: (amount) => dispatch({type: "AmountChanged", payload: {amount}}),
     onDescriptionChanged: (description) => dispatch({type: "DescriptionChanged", payload: {description}}),
-    clearAddBillForm: () => dispatch({type: "ClearAddBillForm"})
+    clearAddBillForm: () => dispatch({type: "ClearAddBillForm"}),
+    invalidateNobt: () => dispatch(invalidateNobt())
   }
 })(AddBillForm)

--- a/src/routes/App/routes/new/modules/addBillForm/actions.js
+++ b/src/routes/App/routes/new/modules/addBillForm/actions.js
@@ -33,13 +33,15 @@ function addBillFailed(error) {
 
 export function addBill(nobtId, bill) {
 
-  return (dispatch) => {
+  return async (dispatch) => {
 
     dispatch(addBillStarted());
 
-    Client.createBill(nobtId, bill).then(
-      response => dispatch(addBillSucceeded(response)),
-      error => dispatch(addBillFailed(error))
-    )
+    try {
+      const response = await Client.createBill(nobtId, bill);
+      dispatch(addBillSucceeded(response))
+    } catch (error) {
+      dispatch(addBillFailed(error))
+    }
   }
 }

--- a/src/routes/App/routes/new/modules/addBillForm/reducer.js
+++ b/src/routes/App/routes/new/modules/addBillForm/reducer.js
@@ -1,5 +1,6 @@
 import SplitStrategyNames from "const/SplitStrategyNames";
 import _debug from "debug";
+import { UPDATE_ADD_BILL_STATUS } from "./actions";
 
 const log = _debug("reducers:addBillForm");
 
@@ -92,14 +93,18 @@ export const addBillFormReducer = (state = initialState, action) => {
     case "ClearAddBillForm": {
       return initialState;
     }
+
+    case UPDATE_ADD_BILL_STATUS: {
+      return {
+        ...state,
+        addBillStatus: action.payload.status
+      }
+    }
   }
 
   return state;
 };
 
-/**
- *
- */
 const initialState = {
   addBillStatus: null,
   debtee: null,

--- a/src/routes/App/routes/new/modules/addBillForm/selectors.js
+++ b/src/routes/App/routes/new/modules/addBillForm/selectors.js
@@ -7,6 +7,7 @@ const getAddBillFormSlice = (state) => state.App.addBillForm;
 export const getAmount = createSelector([ getAddBillFormSlice ], (state) => state.amount);
 export const getDebtee = createSelector([ getAddBillFormSlice ], (state) => state.debtee);
 export const getDescription = createSelector([ getAddBillFormSlice ], (state) => state.description);
+export const getAddBillStatus = createSelector([getAddBillFormSlice], state => state.addBillStatus);
 export const getSplitStrategy = createSelector([ getAddBillFormSlice ], (state) => {
   return state.splitStrategy
 });


### PR DESCRIPTION
We track the progress of the async action in the form component itself and only transition back to the overview once the status changes to SUCCCESSFUL.

This also changes the way the app behaves if adding the bill fails. We now stay on the form-screen and display a snackbar that allows the user to retry the operation. This kind of error handling should be good enough for now.