### PR TITLE
Improve icons

### DIFF
--- a/src/routes/App/components/Nobt.js
+++ b/src/routes/App/components/Nobt.js
@@ -37,7 +37,7 @@ export default class Nobt extends React.Component {
                 <div className={styles.nobtMetadata}>
                   <ul>
                     <li><div><FontIcon value="payment"/><Amount value={35}/></div></li>
-                    <li><div><FontIcon value="supervisor_account"/>10</div></li>
+                    <li><div><FontIcon value="group"/>10</div></li>
                   </ul>
                 </div>
                 <Button

--- a/src/routes/App/routes/balances/components/BalanceOverview/BalanceOverview.js
+++ b/src/routes/App/routes/balances/components/BalanceOverview/BalanceOverview.js
@@ -65,7 +65,7 @@ class BalanceOverview extends React.Component {
                       legend={<Amount theme={AmountTheme} value={person.amount} absolute={false}/>}
                       rightActions={[
                         // TODO Implement instant settle up
-                        balance.me.amount < 0 && (<IconButton icon="payment" disabled/>)
+                        balance.me.amount < 0 // && (<IconButton icon="payment" disabled/>)
                       ]}
                     />
                   ) }


### PR DESCRIPTION
Relace the supervisor_account icon with the group icon. (The icons are similar but the group icon seems to fit our usecase better.)

In addition, this PR completely hides the payment button for balances. (Distracts the user because it is never explained what it does and not clickable.)