### PR TITLE
Add styling code for properly abbreviating long bill titles

### DIFF
--- a/src/routes/App/components/BillItem/BillCardTitleTheme.scss
+++ b/src/routes/App/components/BillItem/BillCardTitleTheme.scss
@@ -1,3 +1,11 @@
 .cardTitle {
   padding-top: 1rem !important;
 }
+
+.title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@import "BillCardTitleTheme.shame";

--- a/src/routes/App/components/BillItem/BillCardTitleTheme.shame.scss
+++ b/src/routes/App/components/BillItem/BillCardTitleTheme.shame.scss
@@ -1,0 +1,9 @@
+.cardTitle {
+
+  // Selecting this div via the child-selectors feels hacky but we don't have a choice as
+  // long as (https://github.com/react-toolbox/react-toolbox/issues/1480) is not resolved.
+  > div {
+    overflow: auto;
+    margin-right: 3rem;
+  }
+}


### PR DESCRIPTION
This PR introduces abbreviation of long bill titles with ellipsis.

**Before:**
![image](https://cloud.githubusercontent.com/assets/5486389/26285837/dd11d580-3e57-11e7-8d0f-6c8ee85190ff.png)


**After:**
![image](https://cloud.githubusercontent.com/assets/5486389/26285835/d6f1147c-3e57-11e7-93e0-c9e1903a0f5a.png)
