### PR TITLE
Reduce custom styling in FilterBillOverlay

### DIFF
--- a/src/routes/App/routes/filter/components/FilterBillOverlay.js
+++ b/src/routes/App/routes/filter/components/FilterBillOverlay.js
@@ -8,8 +8,6 @@ import HOList from "containers/HOList";
 import { ListItem, ListDivider } from "react-toolbox/lib/list";
 import { Avatar } from "components/Avatar";
 import { getBillFilter } from "../../../modules/viewState/selectors";
-import listItemTheme from "./ListItemTheme.scss";
-import listTheme from "./ListTheme.scss";
 import DialogTheme from "components/Dialog/DialogTheme.scss";
 
 const FilterBillOverlay = (props) => (
@@ -17,26 +15,25 @@ const FilterBillOverlay = (props) => (
   <Dialog>
     <h3 className={DialogTheme.header}>Filter bills</h3>
     <HOList
-      theme={listTheme}
       selectable
       items={props.members}
       renderItem={ (name) => (
         <ListItem
           rightIcon={ name === props.currentFilter ? "check_circle" : "radio_button_unchecked" }
-          theme={listItemTheme}
           key={name}
           onClick={ () => {
             props.updateBillFilter(name)
             props.goBack()
           } }
-          leftIcon={<Avatar name={name} medium />}
+          leftActions={[
+            <Avatar name={name} medium />
+          ]}
           caption={name}
         />
       )}>
       <ListDivider />
       <ListItem
         rightIcon={ "" === props.currentFilter ? "check_circle" : "radio_button_unchecked"  }
-        theme={listItemTheme}
         key={"None"}
         caption="None"
         onClick={ () => {

--- a/src/routes/App/routes/filter/components/ListItemTheme.scss
+++ b/src/routes/App/routes/filter/components/ListItemTheme.scss
@@ -1,1 +1,0 @@
-@import "src/styles/personListItem";

--- a/src/routes/App/routes/filter/components/ListTheme.scss
+++ b/src/routes/App/routes/filter/components/ListTheme.scss
@@ -1,4 +1,0 @@
-.list {
-  margin: 0;
-  padding: 0;
-}


### PR DESCRIPTION
This also fixes an already existing styling issue.

|Before|After|
|------|-----|
|![bildschirmfoto vom 2017-06-02 um 14 15 37](https://cloud.githubusercontent.com/assets/5486389/26725332/54983a1e-479e-11e7-9dcb-c23d96ba606a.png)|![bildschirmfoto vom 2017-06-02 um 14 15 29](https://cloud.githubusercontent.com/assets/5486389/26725334/589d886c-479e-11e7-9383-729530bf6295.png)|
