### PR TITLE
Fix naming inconsistency

### DIFF
--- a/src/routes/Landing/components/LandingPage/Team/Team.js
+++ b/src/routes/Landing/components/LandingPage/Team/Team.js
@@ -88,7 +88,7 @@ export default class Team extends React.Component {
       <Grid>
         <Row>
           <Col md={8} mdOffset={2}>
-            <h2>The team behind nobt.</h2>
+            <h2>The team behind nobt.io.</h2>
             <p className={styles.CoffeeInfo}>Crafted with <i className="fa fa-coffee"></i> in Vienna.</p>
             <p>What started as a hackathon by three motivated developers soon turned out to be an actually helpful companion in our daily life.
               Nobt.io is our effort to share this idea with all of you. We hope you enjoy it as much as we do.</p>


### PR DESCRIPTION
We talk about the service "nobt.io" everywhere on the landing page except in the team section. This PR fixes that.