### PR TITLE
Move decoration of error handler to index.html

### DIFF
--- a/src/index.template.ejs
+++ b/src/index.template.ejs
@@ -22,6 +22,15 @@
       	/nobt\.io/
       ]
     }).install();
+
+    const actualErrorHandler = window.onerror;
+
+    let onErrorDecorator = function(msg, url, lineNo, columnNo, error) {
+      actualErrorHandler(msg, url, lineNo, columnNo, error)
+      Raven.showReportDialog();
+    };
+
+    window.onerror = onErrorDecorator;
   </script>
 </head>
 <body>

--- a/src/main.js
+++ b/src/main.js
@@ -70,12 +70,3 @@ if (module.hot) {
     }
   )
 }
-
-const actualErrorHandler = window.onerror;
-
-let onErrorDecorator = (msg, url, lineNo, columnNo, error) => {
-  Raven.showReportDialog();
-  actualErrorHandler(msg, url, lineNo, columnNo, error)
-};
-
-window.onerror = onErrorDecorator;


### PR DESCRIPTION
We have to perform all the initialization of Raven as early as possible.
 This includes wrapping the error handler in order to show the report
 dialog. Tests showed that we have to show the report dialog after
 processing the event.