### PR TITLE
Add babel-polyfill

### DIFF
--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -15,6 +15,7 @@ const paths = config.utils_paths;
 
 let webpackConfig = {
   entry: [
+    "babel-polyfill",
     paths.client("main.js")
   ],
   resolve: {


### PR DESCRIPTION
Adding babel-polyfill as an entry path is the recommended way by babel
for adding the polyfill: https://babeljs.io/docs/usage/polyfill/

This fixes and avoids issues with older browsers like IE11. Lawl.

Fixes #44.