### PR TITLE
Correctly access payload after creating nobt

### DIFF
--- a/src/routes/App/modules/currentNobt/actions.js
+++ b/src/routes/App/modules/currentNobt/actions.js
@@ -14,13 +14,13 @@ function fetchNobtStarted() {
   }
 }
 
-export function fetchNobtSucceeded(nobt) {
+export function fetchNobtSucceeded(response) {
   return (dispatch) => {
 
     dispatch({
       type: UPDATE_FETCH_NOBT_STATUS,
       payload: {
-        nobt,
+        nobt: response.data,
         status: AsyncActionStatus.SUCCESSFUL
       }
     });
@@ -53,7 +53,7 @@ export function fetchNobt(id) {
 
     utils.sleep(1000).then(() => {
       Client.fetchNobt(id).then(
-        response => dispatch(fetchNobtSucceeded(response.data)),
+        response => dispatch(fetchNobtSucceeded(response)),
         error => dispatch(fetchNobtFailed(error))
       )
     })

--- a/src/routes/CreateNobt/modules/actions.js
+++ b/src/routes/CreateNobt/modules/actions.js
@@ -56,8 +56,8 @@ export function createNobt() {
       response => {
 
         utils.sleep(200).then(() => {
-          dispatch(createNobtSucceeded(response))
-          dispatch(fetchNobtSucceeded(response))
+          dispatch(createNobtSucceeded(response));
+          dispatch(fetchNobtSucceeded(response));
         });
 
       },


### PR DESCRIPTION
We incorrectly accessed the payload of the response after creating a
nobt. This caused our reducer to not persist any data in our store which
later on caused issue #52 to happen.

In order to avoid this problem, we now pass the whole response to the
action creator and let it figure out on its own, how to access the
payload. This avoids the duplication and thereby the error.

The error was also the reason, why one always had to click twice on the
link. The first click caused a JS error and the 2nd was an actual click
on a link that made the browser perform an actual navigation (loading
the nobt again instead of using the already locally stored version of it).

Fixes #52.