### PR TITLE
Don't show just an empty screen if Nobt cannot be loaded

### DIFF
--- a/src/components/NobtLoader/UnknownNobt.js
+++ b/src/components/NobtLoader/UnknownNobt.js
@@ -1,0 +1,17 @@
+import React from "react";
+import BrandedAppBar from "../BrandedAppBar/BrandedAppBar";
+import styles from "./UnknownNobt.scss";
+import { FontIcon } from "react-toolbox/lib/font_icon/index";
+
+export default props => (
+  <div>
+    <BrandedAppBar />
+
+    <div className={styles.container}>
+      <span className={styles.icon}>
+        <FontIcon value="error_outline" />
+      </span>
+      <p>Uff. That link didn't work, sorry about that!</p>
+    </div>
+  </div>
+);

--- a/src/components/NobtLoader/UnknownNobt.scss
+++ b/src/components/NobtLoader/UnknownNobt.scss
@@ -1,0 +1,15 @@
+.container {
+  display: flex;
+  width: 100%;
+  height: 90vh;
+
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.icon {
+  > [data-react-toolbox] {
+    font-size: xx-large;
+  }
+}

--- a/src/components/NobtLoader/withNobtLoader.js
+++ b/src/components/NobtLoader/withNobtLoader.js
@@ -1,31 +1,32 @@
 import React from "react";
 import { connect } from "react-redux";
 import { fetchNobt } from "../../routes/App/modules/currentNobt/actions";
-import { getFetchNobtStatus, shouldFetchNobt } from "../../routes/App/modules/currentNobt/selectors";
-import styles from "./NobtLoader.scss"
+import {
+  getFetchNobtStatus,
+  shouldFetchNobt
+} from "../../routes/App/modules/currentNobt/selectors";
+import styles from "./NobtLoader.scss";
 import debug from "debug";
 import AsyncActionStatus from "../../const/AsyncActionStatus";
 import { Snackbar } from "react-toolbox/lib/snackbar/index";
 import { ProgressBar } from "react-toolbox/lib/progress_bar/index";
+import UnknownNobt from "./UnknownNobt";
 
 export default function withNobtLoader(WrappedComponent) {
-
   class NobtLoader extends React.Component {
-
     constructor(props) {
       super(props);
       NobtLoader.fetchNobtIfNecessary(props);
     }
 
     componentWillReceiveProps(nextProps) {
-      NobtLoader.fetchNobtIfNecessary(nextProps)
+      NobtLoader.fetchNobtIfNecessary(nextProps);
     }
 
     static fetchNobtIfNecessary(props) {
       let nobtId = props.routeParams.nobtId;
 
       if (props.shouldFetchNobt) {
-
         debug("NobtLoader")("Fetching nobt.");
 
         props.fetchNobt(nobtId);
@@ -35,42 +36,42 @@ export default function withNobtLoader(WrappedComponent) {
     render() {
       return (
         <div>
-          {
-            this.props.fetchStatus === AsyncActionStatus.SUCCESSFUL && (
-              <WrappedComponent {...this.props} />
-            )
-          }
+          {this.props.fetchStatus === AsyncActionStatus.SUCCESSFUL && (
+            <WrappedComponent {...this.props} />
+          )}
 
-          {
-            this.props.fetchStatus === AsyncActionStatus.IN_PROGRESS && (
-              <div className={styles.loader}>
-                <div className={styles.separator} />
-                <div className={styles.progressBar}>
-                  <ProgressBar type='circular' mode='indeterminate' multicolor />
-                </div>
+          {this.props.fetchStatus === AsyncActionStatus.IN_PROGRESS && (
+            <div className={styles.loader}>
+              <div className={styles.separator} />
+              <div className={styles.progressBar}>
+                <ProgressBar type="circular" mode="indeterminate" multicolor />
               </div>
-            )
-          }
+            </div>
+          )}
+
+          {this.props.fetchStatus === AsyncActionStatus.FAILED && (
+            <UnknownNobt />
+          )}
 
           <Snackbar
-            action='Retry?'
+            action="Retry?"
             active={this.props.fetchStatus === AsyncActionStatus.FAILED}
-            label='Failed to fetch nobt.'
-            type='warning'
+            label="Failed to fetch nobt."
+            type="warning"
             onClick={this.props.invalidateNobtData}
           />
         </div>
-      )
+      );
     }
   }
 
   return connect(
-    (state) => ({
+    state => ({
       shouldFetchNobt: shouldFetchNobt(state),
       fetchStatus: getFetchNobtStatus(state)
     }),
     (dispatch, props) => ({
-      fetchNobt: (id) => dispatch(fetchNobt(id))
+      fetchNobt: id => dispatch(fetchNobt(id))
     })
-  )(NobtLoader)
+  )(NobtLoader);
 }


### PR DESCRIPTION
The current version is very basic, but I lays a foundation and is better than nothing at the moment.

|Before|After|
|---|---|
|![screen shot 2018-04-16 at 21 48 49](https://user-images.githubusercontent.com/5486389/38807449-f6f51658-41bf-11e8-854d-22e9d8de001f.png)|![screen shot 2018-04-16 at 21 47 11](https://user-images.githubusercontent.com/5486389/38807396-c20e26c8-41bf-11e8-9e58-8d3d7d6e2e9a.png)|

Fixes #89.

