### PR TITLE
Add a yarn script for running an API instance locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository contains the source code for the frontend of nobt.io!
 ## Running
 
 1. `yarn run dev`: Starts the webpack-dev-server
-2. See `http://github.com/nobt-io/api` on how to run the API locally. (A locally-run version of the frontend will connect to a local API and not to the production API.)
+2. Clone the API: `git clone http://github.com/nobt-io/api` (ideally as a sibling folder next to this one)
+3. `yarn run api`: Starts a local API instance. A locally started frontend will connect to this one instead of the production API.
 
 ## Building
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "npm": "^5.0.0"
   },
   "scripts": {
+    "api": "cd ../api; PORT=8080 MIGRATE_DATABASE_AT_STARTUP=false USE_IN_MEMORY_DATABASE=true ./gradlew run",
     "clean": "rimraf dist",
     "compile": "webpack --mode development",
     "dev": "webpack-dev-server --mode development",


### PR DESCRIPTION
The script assumes that the API is cloned in a sibling of the frontend. The script is also long-running, which allows conveniently shut it down with CTRL+C.