### PR TITLE
Only add polyfill for Intl if window.Intl does not exist

### DIFF
--- a/src/index.template.ejs
+++ b/src/index.template.ejs
@@ -60,7 +60,27 @@
     document.addEventListener('ravenSuccess', function (event) {
       Raven.showReportDialog({eventId: event.data.event_id});
     }, false);
-  </script>
+	</script>
+	
+	<script type="application/javascript">
+		// Create a list of the features this browser needs.
+    // Beware of overly simplistic detects!
+    var features = [];
+    ('Intl' in window) || features.push('Intl.~locale.en');
+
+    // If any features need to be polyfilled, construct
+    // a script tag to load the polyfills and append it
+    // to the document
+    if (features.length) {
+        var scriptTag = document.createElement('script');
+
+        // Include a `ua` argument set to a supported browser to skip UA identification
+        // (improves response time) and avoid being treated as unknown UA (which would
+        // otherwise result in no polyfills, even with `always`, if UA is unknown)
+        scriptTag.src = 'https://cdn.polyfill.io/v2/polyfill.min.js?features='+features.join(',')+'&flags=gated,always&ua=chrome/50';
+        document.head.appendChild(scriptTag);
+    }
+	</script>
 </head>
 <body>
 <div id="root" style="min-height: 100%"></div>

--- a/src/index.template.ejs
+++ b/src/index.template.ejs
@@ -46,8 +46,6 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Courgette|Comfortaa:700" rel="stylesheet">
 
-  <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en"></script>
-
   <script type="application/javascript">
     Raven.config('<%= SENTRY_DSN %>', {
       release: '<%= COMMIT_HASH %>',


### PR DESCRIPTION
Polyfill.io background:

Polyfill.io checks the User-Agent and determines whether or not the polyfill is needed for this browser.

This PR brings two improvements:

1. Faster loading (through less requests) on modern browsers

Previously, we always made a request to polyfill.io in order to load the polyfill for the Intljs API. On modern browsers, this returned an empty script (because the browser has the Intljs API built in). We now check if window.Intl exists and only if it does not, we fetch it from polyfill.io.

2. Better polyfilling

On some browsers, this polyfilling did not work (IE 10) for example. See this issue in Sentry for example: https://sentry.io/share/issue/67e3d603a8134304be007cfe7bfd4f94/
Because we now check for the presence of `window.Intl`, this should no longer occur.