### PR TITLE
Don't hardcode node-js version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: node_js
-node_js:
-- '8'
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Travis has support for .nvmrc and will use the node version stated
in this file. We should make use of that instead of hardcoding a
node version in the .travis.yml file.