### PR TITLE
Rename build tasks and optimize .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ cache:
     - node_modules
     - ~/.cache
 script:
-- yarn run compile
-- node_modules/.bin/percy exec -- cypress/run.sh
-- yarn run test
 - yarn run prettier
 - yarn run lint
-before_deploy:
-- yarn run deploy
+- yarn run test
+- yarn run build
+- node_modules/.bin/percy exec -- cypress/run.sh
+before_deploy: yarn run build:prod
 deploy:
 - provider: pages
   skip-cleanup: true
@@ -23,12 +22,7 @@ deploy:
   on:
     branch: master
     repo: nobt-io/frontend
-- provider: script
-  skip_cleanup: true
-  script: ".sentry/upload-sourcemaps"
-  on:
-    branch: master
-    repo: nobt-io/frontend
+after_deploy: .sentry/upload-sourcemaps
 notifications:
   email:
     on_success: never

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Frontend",
+  "name": "frontend",
   "version": "0.0.1",
   "description": "Frontend for nobt.io",
   "private": true,
@@ -10,12 +10,12 @@
   "scripts": {
     "api": "cd ../api; PORT=8080 MIGRATE_DATABASE_AT_STARTUP=false USE_IN_MEMORY_DATABASE=true ./gradlew run",
     "clean": "rimraf dist",
-    "compile": "webpack --mode development",
     "dev": "webpack-dev-server --mode development --hot",
+    "build": "webpack --mode development",
+    "build:prod": "yarn run clean && webpack --mode production",
     "lint": "eslint src && tslint -c tslint.json 'src/**/*.ts' 'src/**/*.tsx'",
     "prettier": "prettier --check 'src/**/*.{js, scss, ts, tsx, html}' 'package.json'",
-    "test": "jest",
-    "deploy": "yarn run clean && webpack --mode production"
+    "test": "jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We optimize the tasks that are called in Travis to execute from
fastest to slowest.
In addition, instead of using a custom deployment provider for
uploading the sourcemaps to sentry, we use the after_deploy hook.
Reason is that a 2nd deploy provider re-triggers the before_deploy
hook which means that another build was triggered.