### PR TITLE
Run build:prod as script instead of before_deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
 
     - stage: deploy
       name: "Deployment to Github Pages"
-      before_deploy: yarn run build:prod
+      script: yarn run build:prod
       deploy:
         - provider: pages
           skip-cleanup: true


### PR DESCRIPTION
Otherwise the default script of `yarn test` get activated.