### PR TITLE
Render static contributors within percy

### DIFF
--- a/src/routes/Landing/components/LandingPage/Team/Team.scss
+++ b/src/routes/Landing/components/LandingPage/Team/Team.scss
@@ -86,4 +86,18 @@
   #teamMember3 {
     background-image: url('static/contributors/matthias.png');
   }
+
+  @media percy {
+    #teamMember1 {
+      background-image: url('static/contributors/thomas_single.png');
+    }
+
+    #teamMember2 {
+      background-image: url('static/contributors/david_single.png');
+    }
+
+    #teamMember3 {
+      background-image: url('static/contributors/matthias_single.png');
+    }
+  }
 }


### PR DESCRIPTION
The big picture seems to take quite long to load. Too long for percy in
some situations so it shows up as an empty img when the screenshot is
captured. Setting it to the single image that is there for the mobile
view will hopefully fix this issue.