### PR TITLE
Disable 'Add bill'-button once we sent the request to the server

### DIFF
--- a/cypress/integration/add-bill-page.spec.js
+++ b/cypress/integration/add-bill-page.spec.js
@@ -88,10 +88,10 @@ describe('Add a bill to the nobt', function() {
       method: 'POST',
       url: '/nobts/' + this.nobt.id + '/expenses',
       status: 200,
-      delay: 500,
+      delay: 4000,
       response: {},
     });
 
-    cy.contains('button', 'add bill').click();
+    cy.contains('button', 'add bill').click().should("be.disabled");
   });
 });

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,8 @@ import globalCss from './app.scss';
 import theme from './styles/custom-component-themes';
 import { Provider } from 'react-redux';
 import { ThemeProvider } from 'react-css-themr';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import muiTheme from 'styles/muiTheme';
 
 const history = createHistory();
 const initialState = window.___INITIAL_STATE__;
@@ -33,11 +35,13 @@ const MOUNT_NODE = document.getElementById('root');
 
 ReactDOM.render(
   <IntlProvider locale={navigator.language}>
-    <ThemeProvider theme={theme}>
-      <Provider store={store}>
-        <Router history={history}>{routes}</Router>
-      </Provider>
-    </ThemeProvider>
+    <MuiThemeProvider theme={muiTheme}>
+      <ThemeProvider theme={theme}>
+        <Provider store={store}>
+          <Router history={history}>{routes}</Router>
+        </Provider>
+      </ThemeProvider>
+    </MuiThemeProvider>
   </IntlProvider>,
   MOUNT_NODE
 );

--- a/src/routes/App/routes/bill/components/OverviewPage.js
+++ b/src/routes/App/routes/bill/components/OverviewPage.js
@@ -164,6 +164,7 @@ class OverviewPage extends React.Component {
         <Button
           raised
           primary
+          disabled={this.props.addBillStatus === AsyncActionStatus.IN_PROGRESS}
           onClick={() => createBill(this.props)}
           label="add bill"
           icon="check_circle"

--- a/src/styles/muiTheme.ts
+++ b/src/styles/muiTheme.ts
@@ -1,0 +1,24 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+// this values have been copied over from react-toolbox
+// once we full transitioned to material-ui, we may want
+// to adjust these values (and use the onces computed from `main`?)
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#2d978d',
+      dark: 'rgba(53, 53, 53, 50)',
+      light: '#34aca1'
+    },
+    secondary: {
+      light: '#e3e3e3',
+      main: '#979797',
+      dark: 'white',
+    },
+    error: {
+      main: "#de3226"
+    }
+  },
+});
+
+export default theme;


### PR DESCRIPTION
This is a none-sophisticated attempt to fix #236.

The reason is that the whole page will change eventually so disabling the button seems to be like a reasonable middle-ground of preventing users from clicking twice and not spending too much effort on something that will change in the (near? @duffleit ? :D) future.

Fixes #236.