### PR TITLE
Make percy override for LandingPage actually work

### DIFF
--- a/src/routes/Landing/components/LandingPage/Team/Team.scss
+++ b/src/routes/Landing/components/LandingPage/Team/Team.scss
@@ -86,18 +86,18 @@
   #teamMember3 {
     background-image: url('./contributors/matthias.png');
   }
+}
 
-  @media percy {
-    #teamMember1 {
-      background-image: url('./contributors/thomas_single.png');
-    }
+@media only percy {
+  #teamMember1 {
+    background-image: url('./contributors/thomas_single.png') !important;
+  }
 
-    #teamMember2 {
-      background-image: url('./contributors/david_single.png');
-    }
+  #teamMember2 {
+    background-image: url('./contributors/david_single.png') !important;
+  }
 
-    #teamMember3 {
-      background-image: url('./contributors/matthias_single.png');
-    }
+  #teamMember3 {
+    background-image: url('./contributors/matthias_single.png') !important;
   }
 }


### PR DESCRIPTION
It seems like nested media queries are not supported in SASS/CSS.
The old css block was never emitted to the actual CSS of the page.