### PR TITLE
Show deleted bills in item feed

### DIFF
--- a/cypress/fixtures/nobt-with-deleted-bill.json
+++ b/cypress/fixtures/nobt-with-deleted-bill.json
@@ -1,0 +1,65 @@
+{
+  "id" : "OGjQc4NgsXip",
+  "name" : "Test for deleted bills",
+  "expenses" : [ {
+    "id" : 2,
+    "name" : "A valid bill",
+    "debtee" : "Person 2",
+    "splitStrategy" : "EQUAL",
+    "conversionInformation" : {
+      "foreignCurrency" : "EUR",
+      "rate" : 1
+    },
+    "shares" : [ {
+      "debtor" : "Person 3",
+      "amount" : 6.67
+    }, {
+      "debtor" : "Person 2",
+      "amount" : 6.67
+    }, {
+      "debtor" : "Person 1",
+      "amount" : 6.66
+    } ],
+    "date" : "2019-10-05",
+    "createdOn" : "2019-10-05T11:42:42.158Z",
+    "_links" : {
+      "delete" : "http://localhost:8080/nobts/OGjQc4NgsXip/expenses/2"
+    }
+  } ],
+  "deletedExpenses" : [ {
+    "deletedOn" : "2019-10-05T11:42:45.974Z",
+    "date" : "2019-10-05",
+    "debtee" : "Person 3",
+    "shares" : [ {
+      "debtor" : "Person 1",
+      "amount" : 3.34
+    }, {
+      "debtor" : "Person 2",
+      "amount" : 3.33
+    }, {
+      "debtor" : "Person 3",
+      "amount" : 3.33
+    } ],
+    "conversionInformation" : {
+      "foreignCurrency" : "EUR",
+      "rate" : 1
+    },
+    "createdOn" : "2019-10-05T11:42:29.349Z",
+    "splitStrategy" : "EQUAL",
+    "name" : "A bill to be deleted",
+    "id" : 1
+  } ],
+  "payments" : [ ],
+  "createdOn" : "2019-10-05T11:42:11.241Z",
+  "participatingPersons" : [ "Person 1", "Person 2", "Person 3" ],
+  "currency" : "EUR",
+  "debts" : [ {
+    "debtor" : "Person 3",
+    "amount" : 6.67,
+    "debtee" : "Person 2"
+  }, {
+    "debtor" : "Person 1",
+    "amount" : 6.66,
+    "debtee" : "Person 2"
+  } ]
+}

--- a/cypress/integration/deleted-bills.js
+++ b/cypress/integration/deleted-bills.js
@@ -1,0 +1,37 @@
+/// <reference types="Cypress" />
+
+describe('Deleted bills', function() {
+  beforeEach(function() {
+    cy.fixture("nobt-with-deleted-bill").as("nobt")
+  });
+
+  it('should show deleted bills in the feed', function() {
+    cy.server();
+    cy.route({
+      method: 'GET',
+      url: 'http://localhost:8080/nobts/' + this.nobt.id,
+      status: 200,
+      response: '@nobt',
+    });
+
+    cy.visit('http://localhost:3000/' + this.nobt.id)
+
+    // Waits for the page to actually render
+    cy.contains("A bill to be deleted").should("exist")
+    cy.contains("A valid bill").should("exist")
+
+    // The percy snapshot guarantees we are always rendering deleted bills the same way
+    cy.percySnapshot("Feed with a deleted bill")
+  });
+
+  it('should mention the deleted date in the bills details', function() {
+    cy.contains("A bill to be deleted").click();
+
+    // We purposely don't match against the formatted date because that might be platform/browser specific
+    cy.contains("Deleted on").should("exist");
+  });
+
+  it('should not have a delete action', function() {
+    cy.contains("Delete this bill").should("not.exist");
+  });
+});

--- a/src/routes/App/components/Feed/BillFeedItem.js
+++ b/src/routes/App/components/Feed/BillFeedItem.js
@@ -5,11 +5,12 @@ import Amount from '../../../../components/Amount/Amount';
 import FeedItem from './FeedItem';
 
 const BillFeedItem = ({ feedItem, push }) => {
-  const { id, debtee, subject, amount } = feedItem;
+  const { id, debtee, subject, amount, deleted } = feedItem;
 
   return (
     <FeedItem
       icon="receipt"
+      deleted={deleted}
       caption={`${debtee} paid '${subject}'`}
       legend={<Amount value={amount} />}
       onClick={() =>

--- a/src/routes/App/components/Feed/DeletedFeedItemTheme.scss
+++ b/src/routes/App/components/Feed/DeletedFeedItemTheme.scss
@@ -1,0 +1,10 @@
+.itemContentRoot {
+  overflow: hidden;
+  opacity: 0.3;
+}
+
+.itemText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-decoration: line-through;
+}

--- a/src/routes/App/components/Feed/FeedItem.js
+++ b/src/routes/App/components/Feed/FeedItem.js
@@ -1,13 +1,14 @@
 import { IconButton } from 'react-toolbox-legacy/lib/button/index';
 import { ListItem } from 'react-toolbox-legacy/lib/list/index';
 import FeedItemTheme from './FeedItemTheme.scss';
+import DeletedFeedItemTheme from './DeletedFeedItemTheme.scss';
 import * as React from 'react';
 
-export default ({ icon, caption, legend, onClick }) => (
+export default ({ icon, caption, legend, onClick, deleted }) => (
   <ListItem
     key={caption + legend}
     leftIcon={icon}
-    theme={FeedItemTheme}
+    theme={deleted ? DeletedFeedItemTheme : FeedItemTheme}
     caption={caption}
     legend={legend}
     onClick={onClick && onClick}

--- a/src/routes/App/modules/currentNobt/reducer.js
+++ b/src/routes/App/modules/currentNobt/reducer.js
@@ -18,7 +18,10 @@ const updateFetchNobtStatusActionPayloadHandler = {
         ...(payload.nobt.transactions || []),
         ...(payload.nobt.debts || []),
       ],
-      bills: payload.nobt.expenses,
+      bills: [
+        ...(payload.nobt.expenses || []),
+        ...(payload.nobt.deletedExpenses || []),
+      ],
       createdOn: payload.nobt.createdOn,
       conversionInformation: payload.nobt.conversionInformation,
     },

--- a/src/routes/App/modules/currentNobt/selectors.js
+++ b/src/routes/App/modules/currentNobt/selectors.js
@@ -69,6 +69,8 @@ const getBillsAsFeedItems = createSelector(
       amount: bill.debtee.amount,
       debtee: bill.debtee.name,
       subject: bill.name,
+      deleted: !!bill.deletedOn,
+      deletedOn: bill.deletedOn,
     }))
 );
 
@@ -130,6 +132,7 @@ const deNormalizeBill = e => {
     conversionInformation: e.conversionInformation,
     debtors: debtors,
     actions: e._links,
+    deletedOn: e.deletedOn,
   };
 };
 

--- a/src/routes/App/routes/id/components/BillDetailPage/BillDetailPage.js
+++ b/src/routes/App/routes/id/components/BillDetailPage/BillDetailPage.js
@@ -53,7 +53,7 @@ class BillDetailPage extends React.Component {
     }
 
     const { bill, nobtCurrency } = this.props;
-    const { debtee } = bill;
+    const { debtee, deletedOn } = bill;
 
     const items = [
       <ListItem
@@ -127,6 +127,32 @@ class BillDetailPage extends React.Component {
       );
     }
 
+    if (deletedOn) {
+      items.push(
+        <ListItem
+          key="Date_Deleted"
+          ripple={false}
+          caption={
+            <FormattedMessage
+              id="BillDetailPage.time_added_caption"
+              defaultMessage="Deleted on {timestamp}."
+              values={{
+                timestamp: (
+                  <FormattedDate
+                    value={new Date(deletedOn)}
+                    year="numeric"
+                    month="long"
+                    day="2-digit"
+                  />
+                ),
+              }}
+            />
+          }
+          leftActions={[<FontIcon value="delete" />]}
+        />
+      );
+    }
+
     return (
       <div>
         <AppBar
@@ -163,15 +189,17 @@ class BillDetailPage extends React.Component {
             ))}
           </List>
 
-          <List>
-            <ListSubHeader caption="Actions" />
-            <ListItem
-              primary
-              leftIcon="delete"
-              caption="Delete this bill"
-              onClick={this.showDialog}
-            />
-          </List>
+          {this.props.canBillBeDeleted && (
+            <List>
+              <ListSubHeader caption="Actions" />
+              <ListItem
+                primary
+                leftIcon="delete"
+                caption="Delete this bill"
+                onClick={this.showDialog}
+              />
+            </List>
+          )}
 
           <DeleteBillConfirmationDialog
             active={this.state.showDeleteBillConfirmationDialog}


### PR DESCRIPTION
Deleted bills are shown with a strike-through decoration and an opacity of 30%.
In addition, when navigating to the details, it shows the deletion date next to the other detail information.

|Feed|Details|
|---|---|
|![Screen Shot 2019-10-05 at 22 05 39](https://user-images.githubusercontent.com/5486389/66254636-52c4ae00-e7bc-11e9-82f3-f82f4b463771.png)|![Screen Shot 2019-10-05 at 22 05 43](https://user-images.githubusercontent.com/5486389/66254640-57896200-e7bc-11e9-9021-a98088b5ac0d.png)|

